### PR TITLE
Fix navbar link color to white

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -59,3 +59,8 @@ body {
 .user-info {
   min-width: 800px;
 }
+
+.navbar-nav .nav-item .nav-link {
+   color: #FFFFFF;
+} 
+


### PR DESCRIPTION
issue : https://github.com/Wilcolab/Anythink-Market-1acuhxdu/issues/1

# Description
Add CSS rule setting .navbar-nav .nav-item .nav-link to #FFFFFF so navigation links remain visible on the dark background.